### PR TITLE
Adapt to changed nullness annotations

### DIFF
--- a/src/main/java/org/plumelib/util/UnmodifiableIdentityHashMap.java
+++ b/src/main/java/org/plumelib/util/UnmodifiableIdentityHashMap.java
@@ -10,6 +10,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.checker.signedness.qual.UnknownSignedness;
@@ -205,7 +206,7 @@ public class UnmodifiableIdentityHashMap<K, V> extends IdentityHashMap<K, V> {
 
   @Override
   public @PolyNull V merge(
-      K key, V value, BiFunction<? super V, ? super V, ? extends @PolyNull V> remappingFunction) {
+      K key, @NonNull V value, BiFunction<? super @NonNull V, ? super @NonNull V, ? extends @PolyNull V> remappingFunction) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/plumelib/util/UnmodifiableIdentityHashMap.java
+++ b/src/main/java/org/plumelib/util/UnmodifiableIdentityHashMap.java
@@ -206,7 +206,9 @@ public class UnmodifiableIdentityHashMap<K, V> extends IdentityHashMap<K, V> {
 
   @Override
   public @PolyNull V merge(
-      K key, @NonNull V value, BiFunction<? super @NonNull V, ? super @NonNull V, ? extends @PolyNull V> remappingFunction) {
+      K key,
+      @NonNull V value,
+      BiFunction<? super @NonNull V, ? super @NonNull V, ? extends @PolyNull V> remappingFunction) {
     throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
https://github.com/eisop/jdk/pull/41 makes the signature of `Map.merge` more flexible.
This PR adapts the implementation here to make the override valid.