### PR TITLE
Use JDK 21 for Gradle in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,13 +16,20 @@ jobs:
       with:
         fetch-depth: 1
         show-progress: false
+    - name: Set up JDK 21 for Gradle
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 21
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
-    - name: java -version
-      run: java -version
+    - name: Use JDK 21 for Gradle
+      run: mkdir -p ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
+    - name: Version information
+      run: java -version && ./gradlew -version
     - name: ./gradlew build javadoc
       run: ./gradlew build javadoc
     - name: Setup local CF


### PR DESCRIPTION
This PR updates the CI workflow so that Gradle always runs using JDK 21, regardless of the JDK under test. This is achieved by setting the `org.gradle.java.home` property to point to JDK 21. 

This change is necessary because allowing Gradle to follow the JDK under test causes failures on versions below 17, see [example](https://github.com/eisop-plume-lib/plume-util/actions/runs/15360390798/job/43226737922).